### PR TITLE
Changelog.md improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,3 @@
-#####
-
 # Changelog
 
 All notable changes to "vscode-autoit", display name "AutoIt", will be documented in this file.
@@ -79,18 +77,3 @@ Go to [legend](#legend---types-of-changes) for further information about the typ
 [1.1.1]: https://github.com/genius257/vscode-autoit/compare/1.1.0...1.1.1
 [1.1.0]: https://github.com/genius257/vscode-autoit/compare/1.0.0...1.1.0
 [1.0.0]: https://github.com/genius257/vscode-autoit/releases/tag/1.0.0
-
----
-
-### Legend - Types of changes
-
-- `Added` for new features.
-- `Changed` for changes in existing functionality.
-- `Deprecated` for soon-to-be removed features.
-- `Fixed` for any bug fixes.
-- `Removed` for now removed features.
-- `Security` in case of vulnerabilities.
-
-##
-
-[To the top](#)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
-# Change Log
+#####
 
-All notable changes to the "autoit" extension will be documented in this file.
+# Changelog
+
+All notable changes to "vscode-autoit", display name "AutoIt", will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Go to [legend](#legend---types-of-changes) for further information about the types of changes.
 
 ## [Unreleased]
 
@@ -67,3 +71,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - AutoIt3 syntax highlighting
 - AutoIt2 syntax highlighting
+
+[Unreleased]: https://github.com/genius257/vscode-autoit/compare/1.2.2...HEAD
+[1.2.2]: https://github.com/genius257/vscode-autoit/compare/1.2.1...1.2.2
+[1.2.1]: https://github.com/genius257/vscode-autoit/compare/1.2.0...1.2.1
+[1.2.0]: https://github.com/genius257/vscode-autoit/compare/1.1.1...1.2.0
+[1.1.1]: https://github.com/genius257/vscode-autoit/compare/1.1.0...1.1.1
+[1.1.0]: https://github.com/genius257/vscode-autoit/compare/1.0.0...1.1.0
+[1.0.0]: https://github.com/genius257/vscode-autoit/releases/tag/1.0.0
+
+---
+
+### Legend - Types of changes
+
+- `Added` for new features.
+- `Changed` for changes in existing functionality.
+- `Deprecated` for soon-to-be removed features.
+- `Fixed` for any bug fixes.
+- `Removed` for now removed features.
+- `Security` in case of vulnerabilities.
+
+##
+
+[To the top](#)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,6 @@ All notable changes to "vscode-autoit", display name "AutoIt", will be documente
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-Go to [legend](#legend---types-of-changes) for further information about the types of changes.
-
 ## [Unreleased]
 
 ## [1.2.2] - 2023-02-24


### PR DESCRIPTION
Like in issue #25 described, this leads to the possibility of compare TAG versions by the click on a SemVer number in the changelog file. This is the first commit without your requests @genius257:

> And personally i have a few changes i would request:
> - I don't see the legend part being so relevant, as it is almost a copy paste from the KeepAChangelog page?
> - The return to top, i can see use cases for, but it does seem to add clutter to a document, only to provide an alternative to the `Home` button on the keyboard/using the mouse to click on the scroll bar?

Like I wrote in the issue, if you wish me to remove the legend and the "To the top" anchar, I will do it by an additional commit 😇 .

Best regards
Sven